### PR TITLE
fix: skip recipient id in ToBytes for type 1 and 4 

### DIFF
--- a/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/DelegateRegistrationTest.cs
+++ b/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/DelegateRegistrationTest.cs
@@ -50,6 +50,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
             Assert.AreEqual((string)transaction["asset"]["delegate"]["username"], actual.Asset["delegate"]["username"]);
+            Assert.IsTrue(actual.Verify());
         }
 
         [TestMethod]
@@ -70,6 +71,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signSignature"], actual.SignSignature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
             Assert.AreEqual((string)transaction["asset"]["delegate"]["username"], actual.Asset["delegate"]["username"]);
+            Assert.IsTrue(actual.Verify());
         }
     }
 }

--- a/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/MultiSignatureRegistrationTest.cs
+++ b/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/MultiSignatureRegistrationTest.cs
@@ -51,6 +51,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["id"], actual.Id);
             Assert.AreEqual((byte)transaction["asset"]["multisignature"]["min"], actual.Asset["multisignature"]["min"]);
             Assert.AreEqual((byte)transaction["asset"]["multisignature"]["lifetime"], actual.Asset["multisignature"]["lifetime"]);
+            Assert.IsTrue(actual.Verify());
 
             CollectionAssert.AreEqual(transaction["asset"]["multisignature"]["keysgroup"].ToObject<List<string>>(), actual.Asset["multisignature"]["keysgroup"]);
         }

--- a/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/SecondSignatureRegistrationTest.cs
+++ b/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/SecondSignatureRegistrationTest.cs
@@ -51,6 +51,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
             Assert.AreEqual((string)transaction["asset"]["signature"]["publicKey"], actual.Asset["signature"]["publicKey"]);
+            Assert.IsTrue(actual.Verify());
 
             // special case as the type 1 transaction itself has no recipientId
             Assert.AreEqual(Address.FromPublicKey(PublicKey.FromHex(actual.SenderPublicKey)), actual.RecipientId);

--- a/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/TransferTest.cs
+++ b/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/TransferTest.cs
@@ -51,6 +51,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["recipientId"], actual.RecipientId);
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
         }
 
         [TestMethod]
@@ -72,6 +73,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["signSignature"], actual.SignSignature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
         }
 
         [TestMethod]
@@ -93,6 +95,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["vendorField"], actual.VendorField);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
         }
 
         [TestMethod]
@@ -115,6 +118,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signSignature"], actual.SignSignature);
             Assert.AreEqual((string)transaction["vendorField"], actual.VendorField);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
         }
 
         [TestMethod]
@@ -136,6 +140,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["recipientId"], actual.RecipientId);
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
 
             Assert.AreEqual(Encoders.Hex.EncodeData(new Crypto.Transactions.Serializer(actual).Serialize()), fixture["serialized"]);
         }
@@ -160,6 +165,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["signSignature"], actual.SignSignature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
 
             Assert.AreEqual(Encoders.Hex.EncodeData(new Crypto.Transactions.Serializer(actual).Serialize()), fixture["serialized"]);
         }

--- a/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/VoteTest.cs
+++ b/ArkEcosystem.Crypto.Tests/Transactions/Deserializers/VoteTest.cs
@@ -51,6 +51,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["recipientId"], actual.RecipientId);
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
 
             CollectionAssert.AreEqual(actual.Asset["votes"], transaction["asset"]["votes"].ToObject<List<string>>());
         }
@@ -74,6 +75,7 @@ namespace ArkEcosystem.Crypto.Tests.Transactions.Deserializers
             Assert.AreEqual((string)transaction["signature"], actual.Signature);
             Assert.AreEqual((string)transaction["signSignature"], actual.SignSignature);
             Assert.AreEqual((string)transaction["id"], actual.Id);
+            Assert.IsTrue(actual.Verify());
 
             CollectionAssert.AreEqual(actual.Asset["votes"], transaction["asset"]["votes"].ToObject<List<string>>());
         }

--- a/ArkEcosystem.Crypto/Transactions/Transaction.cs
+++ b/ArkEcosystem.Crypto/Transactions/Transaction.cs
@@ -184,7 +184,8 @@ namespace ArkEcosystem.Crypto.Transactions
                 writer.Write(Timestamp);
                 writer.Write(Encoders.Hex.DecodeData(SenderPublicKey));
 
-                if (RecipientId != null)
+                var skipRecipientId = Type == Enums.TransactionTypes.SECOND_SIGNATURE_REGISTRATION || Type == Enums.TransactionTypes.MULTI_SIGNATURE_REGISTRATION;
+                if (RecipientId != null && !skipRecipientId)
                 {
                     writer.Write(Encoders.Base58Check.DecodeData(RecipientId));
                 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.1.1
+
+### Fixed
+- Skip recipient id in `ToBytes` for type 1 and 4 transactions.
+
 ## 0.1.0 - 2018-07-18
 - Initial Release


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In second signature and multi signature transactions the recipient id is not supposed to be included in the signature/id calculation. Add an additional check to `ToBytes` to explicitely exclude the recipientId. This also allows such transactions to be verified, even if the recipientId is set.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
<!--